### PR TITLE
Fix package name for publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@dopplerhq/vscode",
+  "name": "doppler-vscode",
   "private": true,
   "displayName": "Doppler",
   "description": "Edit your secrets where you edit your code, with 2 way sync.",


### PR DESCRIPTION
The previous name we were using was to support our NPM org but since we are publishing to the VS Code marketplace, we have to honor their naming conventions.