### PR TITLE
Fix case-sensitivity issue on Windows

### DIFF
--- a/src/lib/helpers/index.ts
+++ b/src/lib/helpers/index.ts
@@ -1,7 +1,9 @@
 import DopplerTerminal from "./terminal";
 import DopplerParser from "./parser";
 import { interval } from "./interval";
+import { isWindows } from "./os";
 
 export const terminal = new DopplerTerminal();
 export const parser = new DopplerParser();
 export { interval };
+export { isWindows };

--- a/src/lib/helpers/os.ts
+++ b/src/lib/helpers/os.ts
@@ -1,0 +1,5 @@
+import os from "os";
+
+export function isWindows() {
+  return os.platform() === "win32";
+}


### PR DESCRIPTION
There was a bug on Windows where the extension would just spin seemingly forever (there was actually a 5 minute timeout) waiting for a valid login – even if you were logged in properly. This was due to using a non-Windows friendly path format and then additionally by a case-sensitivity issue. The Doppler CLI is designed to respect case-sensitive filenames and paths. NodeJS returns Windows paths with the drive letter in lowercase – even though the actual system path uses capitalized drive letters. This change ensures that the drive letter on absolute paths in Windows is capitalized.

Closes ENG-6304 and #15.