### PR TITLE
Bump version to 0.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Edit your secrets where you edit your code, with 2 way sync.",
   "publisher": "doppler",
   "author": "doppler",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "license": "Apache-2.0",
   "homepage": "https://github.com/dopplerhq/vscode",
   "icon": "media/icon.png",


### PR DESCRIPTION
Bumping the extension version to 0.0.4 to release a bugfix for Windows (#17).