### PR TITLE
Omit dev dependencies in npm audit

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,10 +11,10 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: "16.x"
+          node-version: "22.x"
           registry-url: "https://registry.npmjs.org"
 
       - name: Get Version

--- a/.github/workflows/scanners.yaml
+++ b/.github/workflows/scanners.yaml
@@ -69,7 +69,7 @@ jobs:
     name: NPM Audit
     steps:
       - uses: actions/checkout@v2
-      - run: set -eo pipefail; npm audit 2>&1| tee ./audit-report.txt
+      - run: set -eo pipefail; npm audit --omit=dev 2>&1| tee ./audit-report.txt
       - uses: actions/upload-artifact@master
         if: always()
         with:

--- a/.github/workflows/scanners.yaml
+++ b/.github/workflows/scanners.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Trufflehog
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Extract branch name
         shell: bash
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     name: NPM Linter
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: NPM Build
         run: npm install --frozen-lockfile
       - run: set -eo pipefail; npm run lint 2>&1| tee ./linter-report.txt
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     name: NPM Prettier
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: NPM Build
         run: npm install --frozen-lockfile
       - run: set -eo pipefail; npm run prettier 2>&1| tee ./prettier-report.txt
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     name: NPM Typecheck
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: NPM Build
         run: npm install --frozen-lockfile
       - run: set -eo pipefail; npm run typecheck 2>&1| tee ./typecheck-report.txt
@@ -68,7 +68,7 @@ jobs:
     runs-on: ubuntu-latest
     name: NPM Audit
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - run: set -eo pipefail; npm audit --omit=dev 2>&1| tee ./audit-report.txt
       - uses: actions/upload-artifact@master
         if: always()

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     name: Tests
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: "16.x"
+          node-version: "22.x"
           registry-url: "https://registry.npmjs.org"
 
       - name: Install CLI


### PR DESCRIPTION
Updates the audit check inside the scanners workflow to omit dev dependencies.

This also updates the CI steps to use the latest versions of github-provided actions, and updates node to 22. The older versions are no longer supported.